### PR TITLE
Changes to wrapper required for integration with AJ Bridge (RT)

### DIFF
--- a/patch/node/node_wrapper.h
+++ b/patch/node/node_wrapper.h
@@ -50,7 +50,6 @@ struct _JSValue {
 };
 
 typedef struct _JSValue JS_Value;
-typedef struct _JSValue JS_Result;
 
 // Call a JS side function.
 // fnc: Function

--- a/patch/node/node_wrapper.h
+++ b/patch/node/node_wrapper.h
@@ -1,5 +1,4 @@
 // See LICENSE file
-
 #ifndef SRC_JS_HEADER_
 #define SRC_JS_HEADER_
 
@@ -17,7 +16,7 @@ extern "C" {
 #endif
 
 #ifndef JXCORE_WRAPPER
-enum _JSBaseType {
+enum class _JSBaseType {
   RT_Int32 = 1,
   RT_Double = 2,
   RT_Boolean = 3,
@@ -29,7 +28,7 @@ enum _JSBaseType {
   RT_Error = 9,
   RT_Function = 10
 };
-typedef enum _JSBaseType JS_ValueType;
+typedef enum class _JSBaseType JS_ValueType;
 #else
 typedef enum _JXType _JSBaseType;
 typedef enum _JXType JS_ValueType;
@@ -51,6 +50,7 @@ struct _JSValue {
 };
 
 typedef struct _JSValue JS_Value;
+typedef struct _JSValue JS_Result;
 
 // Call a JS side function.
 // fnc: Function

--- a/tests/commons/common-posix.h
+++ b/tests/commons/common-posix.h
@@ -25,29 +25,29 @@
 
 void ConvertResult(JS_Value &result, std::string &to_result) {
   switch (result.type_) {
-    case RT_Null:
+    case JS_ValueType::RT_Null:
       to_result = "null";
       break;
-    case RT_Undefined:
+    case JS_ValueType::RT_Undefined:
       to_result = "undefined";
       break;
-    case RT_Boolean:
+    case JS_ValueType::RT_Boolean:
       to_result = JS_GetBoolean(&result) ? "true" : "false";
       break;
-    case RT_Int32: {
+    case JS_ValueType::RT_Int32: {
       std::stringstream ss;
       ss << JS_GetInt32(&result);
       to_result = ss.str();
     } break;
-    case RT_Double: {
+    case JS_ValueType::RT_Double: {
       std::stringstream ss;
       ss << JS_GetDouble(&result);
       to_result = ss.str();
     } break;
-    case RT_Buffer:
-    case RT_Object:
-    case RT_Error:
-    case RT_String: {
+    case JS_ValueType::RT_Buffer:
+    case JS_ValueType::RT_Object:
+    case JS_ValueType::RT_Error:
+    case JS_ValueType::RT_String: {
       char *_ = JS_GetString(&result);
       to_result = _;
       free(_);


### PR DESCRIPTION
Minor changes required to node wrapper, to consume in Bridge RT.

Other changes required to build Bridge RT,   (first Clone https://github.com/tjaffri/msiot-samples)
1. ScriptAdapterLib project  
  Remove #include <jx.h> from precompiled header
  Make minor changes (including node_wrapper.h and other issues)
  Place node.lib and chakracore.lib a dir and added it to additional libs to link for this project. 
2. rebuild UspTestApp. (that rebuilds everything). 
3. Now deploy the test app and place BridgeRT.dll, node.dll, chakracore.dll under <releaseType>\X64\Appx and press Initialize DSB & Add Device. 

Ensure to install IoT Explorer (store app) and enable loop back exception for IOT explorer. (https://loopback.codeplex.com/)
