### PR TITLE
Fixing default arch for tests to match nodejs (x64) and accounting for NODE_ENGINE_CHAKRA

### DIFF
--- a/build.js
+++ b/build.js
@@ -157,11 +157,12 @@ var createBatch = function() {
 
   if (!isWindows) {
     fs.writeFileSync('./temp/test.bat', 'cd tests\nnode runtests.js --target=' + forced_target
-                                      + ' --dest-cpu=' + (args.hasOwnProperty('--dest-cpu') ? args['--dest-cpu'] : 'ia32')
+                                      + ' --dest-cpu=' + (args.hasOwnProperty('--dest-cpu') ? args['--dest-cpu'] : 'x64')
                                       + '\nexit $?');
   } else {
     fs.writeFileSync('./temp/test.bat', 'cd tests\nnode runtests.js --target=' + forced_target
-                                      + ' --dest-cpu=' + (args.hasOwnProperty('--dest-cpu') ? args['--dest-cpu'] : 'ia32')
+                                      + ' --dest-cpu=' + (args.hasOwnProperty('--dest-cpu') ? args['--dest-cpu'] : 'x64')
+                                      + ' --mode=' + (args.hasOwnProperty('--release') ? args['--release'] : 'Debug')
                                       + '\nexit %errorlevel%');
   }
 

--- a/patch/node/node_internal_wrapper.cc
+++ b/patch/node/node_internal_wrapper.cc
@@ -33,14 +33,14 @@ void __StartNodeInstance(void* arg, void (*DEFINE_NATIVES)()) {
     Locker locker(isolate);
     Isolate::Scope isolate_scope(isolate);
     HandleScope handle_scope(isolate);
-#ifndef NODE_ENGINE_CHAKRACORE
+#if !defined(NODE_ENGINE_CHAKRACORE) && !defined(NODE_ENGINE_CHAKRA)
     node_isolate_data =
         new IsolateData(isolate, instance_data->event_loop(),
                         array_buffer_allocator.zero_fill_field());
 #endif
     Local<Context> context = Context::New(isolate);
     Context::Scope context_scope(context);
-#if defined(NODE_ENGINE_CHAKRACORE)
+#if defined(NODE_ENGINE_CHAKRACORE) || defined(NODE_ENGINE_CHAKRA)
       node_isolate_data =
           new IsolateData(isolate, instance_data->event_loop(),
                           array_buffer_allocator.zero_fill_field());

--- a/patch/node/node_wrapper.cc
+++ b/patch/node/node_wrapper.cc
@@ -27,7 +27,7 @@ class ScopeWatch {
   bool EnteredNewScope() { return entered_; }
 
   void EnterScope() {
-#ifndef NODE_ENGINE_CHAKRACORE
+#if !defined(NODE_ENGINE_CHAKRACORE) && !defined(NODE_ENGINE_CHAKRA)
     if (!in_scope_faked_)
       isolate_->Enter();
 #endif
@@ -38,7 +38,7 @@ class ScopeWatch {
 
   ~ScopeWatch() {
     if (entered_) {
-#ifndef NODE_ENGINE_CHAKRACORE
+#if !defined(NODE_ENGINE_CHAKRACORE) && !defined(NODE_ENGINE_CHAKRA)
       if (!in_scope_faked_)
         isolate_->Exit();
 #endif
@@ -1164,7 +1164,7 @@ void JS_QuitLoop() {
 }
 
 bool JS_IsV8() {
-#ifndef NODE_ENGINE_CHAKRACORE
+#if !defined(NODE_ENGINE_CHAKRACORE) && !defined(NODE_ENGINE_CHAKRA)
   return true;
 #else
   return false;
@@ -1174,7 +1174,7 @@ bool JS_IsV8() {
 bool JS_IsSpiderMonkey() { return false; }
 
 bool JS_IsChakra() {
-#ifdef NODE_ENGINE_CHAKRACORE
+#if defined(NODE_ENGINE_CHAKRACORE) || defined(NODE_ENGINE_CHAKRA)
   return true;
 #else
   return false;


### PR DESCRIPTION
In previous PR #13 , the default Arch was changed to x64 and missed to change for tests too (when --dest-cpu is not specified). 
